### PR TITLE
Update MySQL compiler name file

### DIFF
--- a/lib/query/QueryCompiler.js
+++ b/lib/query/QueryCompiler.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 // @ts-ignore
-const QueryCompiler_MySQL = require("knex/lib/dialects/mysql/query/compiler");
+const QueryCompiler_MySQL = require("knex/lib/dialects/mysql/query/mysql-querycompiler");
 class QueryCompiler extends QueryCompiler_MySQL {
     constructor(client, builder) {
         super(client, builder);

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "snowflake-sdk": "1.6.0"
   },
   "peerDependencies": {
-    "knex": "^0.15.2"
+    "knex": "1.0.3"
   },
   "devDependencies": {
     "@types/bluebird": "3.5.29",
@@ -66,7 +66,7 @@
     "@types/node": "13.7.0",
     "chai": "4.2.0",
     "jest": "25.1.0",
-    "knex": "0.20.4",
+    "knex": "1.0.3",
     "mocha": "7.1.1",
     "mysql": "2.18.1",
     "sinon": "9.0.1",


### PR DESCRIPTION
The latest version of Knex (1.0.3) changes the file name _knex/lib/dialects/mysql/query/compiler_ now the name is: _knex/lib/dialects/mysql/query/mysql-querycompiler_

This is breaking the code using last version of knex and last version of this package
```
Error: Cannot find module 'knex/lib/dialects/mysql/query/compiler'
Require stack:
/node_modules/knex-snowflake-dialect/src/query/QueryCompiler.ts:2:1)
```