### PR TITLE
Update all mysql compiler paths to match current knex version paths

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ const lodash_1 = require("lodash");
 const QueryCompiler_1 = require("./query/QueryCompiler");
 const schema_1 = require("./schema");
 const ColumnBuilder = require("knex/lib/schema/columnbuilder");
-const ColumnCompiler_MySQL = require("knex/lib/dialects/mysql/schema/columncompiler");
+const ColumnCompiler_MySQL = require("knex/lib/dialects/mysql/schema/mysql-columncompiler");
 const Transaction = require("knex/lib/transaction");
 const util_1 = require("util");
 class SnowflakeDialect extends Knex.Client {

--- a/lib/query/QueryCompiler.js
+++ b/lib/query/QueryCompiler.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 // @ts-ignore
-const QueryCompiler_MySQL = require("knex/lib/dialects/mysql/query/compiler");
+const QueryCompiler_MySQL = require("knex/lib/dialects/mysql/query/mysql-querycompiler");
 class QueryCompiler extends QueryCompiler_MySQL {
     constructor(client, builder) {
         super(client, builder);

--- a/lib/schema/SchemaCompiler.js
+++ b/lib/schema/SchemaCompiler.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 // @ts-ignore
-const SchemaCompiler_MySQL = require("knex/lib/dialects/mysql/schema/compiler");
+const SchemaCompiler_MySQL = require("knex/lib/dialects/mysql/schema/mysql-compiler");
 class SchemaCompiler extends SchemaCompiler_MySQL {
     constructor(client, builder) {
         super(client, builder);

--- a/lib/schema/TableCompiler.js
+++ b/lib/schema/TableCompiler.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 // @ts-ignore
-const TableCompiler_MySQL = require("knex/lib/dialects/mysql/schema/tablecompiler");
+const TableCompiler_MySQL = require("knex/lib/dialects/mysql/schema/mysql-tablecompiler");
 class TableCompiler extends TableCompiler_MySQL {
     constructor(client, builder) {
         super(client, builder);


### PR DESCRIPTION
This package does not work with the current version of knex due to the file names of some scripts changing, this pr is to make sure the references to these files match with the current knex names.