### PR TITLE
Updating the pathnames for latest knex version and changing package name for this fork

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ const lodash_1 = require("lodash");
 const QueryCompiler_1 = require("./query/QueryCompiler");
 const schema_1 = require("./schema");
 const ColumnBuilder = require("knex/lib/schema/columnbuilder");
-const ColumnCompiler_MySQL = require("knex/lib/dialects/mysql/schema/columncompiler");
+const ColumnCompiler_MySQL = require("knex/lib/dialects/mysql/schema/mysql-columncompiler");
 const Transaction = require("knex/lib/transaction");
 const util_1 = require("util");
 class SnowflakeDialect extends Knex.Client {

--- a/lib/query/QueryCompiler.js
+++ b/lib/query/QueryCompiler.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 // @ts-ignore
-const QueryCompiler_MySQL = require("knex/lib/dialects/mysql/query/compiler");
+const QueryCompiler_MySQL = require("knex/lib/dialects/mysql/query/mysql-querycompiler");
 class QueryCompiler extends QueryCompiler_MySQL {
     constructor(client, builder) {
         super(client, builder);

--- a/lib/schema/SchemaCompiler.js
+++ b/lib/schema/SchemaCompiler.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 // @ts-ignore
-const SchemaCompiler_MySQL = require("knex/lib/dialects/mysql/schema/compiler");
+const SchemaCompiler_MySQL = require("knex/lib/dialects/mysql/schema/mysql-compiler");
 class SchemaCompiler extends SchemaCompiler_MySQL {
     constructor(client, builder) {
         super(client, builder);

--- a/lib/schema/TableCompiler.js
+++ b/lib/schema/TableCompiler.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 // @ts-ignore
-const TableCompiler_MySQL = require("knex/lib/dialects/mysql/schema/tablecompiler");
+const TableCompiler_MySQL = require("knex/lib/dialects/mysql/schema/mysql-tablecompiler");
 class TableCompiler extends TableCompiler_MySQL {
     constructor(client, builder) {
         super(client, builder);

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "knex-snowflake-dialect",
-  "version": "0.2.5",
+  "name": "pmg-knex-snowflake-dialect",
+  "version": "1.0.0",
   "description": "knex.js dialect for the Snowflake data warehouse",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "directories": {
-    "lib": "lib"
+    "lib": "lib",
+    "test": "test"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
This PR is to make it so the snowflake knex dialect can be used with the latest version of knex because of the path name changes and also to change package name for use in dwh