### PR TITLE
update version in package-lock to match

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "knex-snowflake-dialect",
-  "version": "0.2.6",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
npm version giving an error in the CI pipeline while trying to run `npm version`, I _think_ this might fix it
https://app.circleci.com/pipelines/github/deliverr/data-knex-snowflake-dialect/31/workflows/036194b9-4619-4432-9841-f00fd2bcdda4/jobs/97