### PR TITLE
Making sure to declare driverName

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -240,3 +240,5 @@ export class SnowflakeDialect extends knex.Client {
   }
 
 }
+SnowflakeDialect.prototype.driverName = 'snowflake-sdk';
+


### PR DESCRIPTION
According to [knex's documentation](https://github.com/knex/knex/blob/master/UPGRADING.md) y'all are not currently declaring your driverName anywhere. This PR is just to add one of the ways that they describe and I've found that works